### PR TITLE
ci: skip workflow runs on bot PRs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   semantic-pull-request:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -32,6 +33,7 @@ jobs:
           wip: false
 
   spell-check:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     defaults:
       run:
         working-directory: .


### PR DESCRIPTION
Adds an `if` condition to every job so that dependency-bot PRs (dependabot, renovate, etc.) do not trigger Actions runs, reducing unnecessary minutes usage.